### PR TITLE
FIX: Incorrect parsing boolean

### DIFF
--- a/lib/app_badger_method_channel.dart
+++ b/lib/app_badger_method_channel.dart
@@ -21,7 +21,7 @@ class MethodChannelAppBadger extends AppBadgerPlatform {
     return methodChannel.invokeMethod(
       'remove',
       {
-        'cancelNotifications': cancelNotifications,
+        'cancelNotifications': cancelNotifications.toString(),
       },
     );
   }

--- a/test/app_badger_test.dart
+++ b/test/app_badger_test.dart
@@ -11,7 +11,9 @@ class MockAppBadgerPlatform
   Future<bool> isSupported() => Future.value(true);
 
   @override
-  Future<void> remove() async {}
+  Future<void> remove({
+    bool cancelNotifications = false,
+  }) async {}
   @override
   Future<void> updateCount(int count) async {}
 }


### PR DESCRIPTION
Fixes: 

02-15 11:04:54.010 E/MethodChannel#app_badger(28454): Failed to handle method call
02-15 11:04:54.010 E/MethodChannel#app_badger(28454): java.lang.ClassCastException: java.lang.Boolean cannot be cast to java.lang.String
02-15 11:04:54.010 E/MethodChannel#app_badger(28454): 	at f4.b.onMethodCall(Unknown Source:106)
02-15 11:04:54.010 E/MethodChannel#app_badger(28454): 	at lf.k$a.a(Unknown Source:17)
02-15 11:04:54.010 E/MethodChannel#app_badger(28454): 	at ze.c.l(Unknown Source:18)
02-15 11:04:54.010 E/MethodChannel#app_badger(28454): 	at ze.c.m(Unknown Source:40)
02-15 11:04:54.010 E/MethodChannel#app_badger(28454): 	at ze.c.i(Unknown Source:0)
02-15 11:04:54.010 E/MethodChannel#app_badger(28454): 	at ze.b.run(Unknown Source:12)
02-15 11:04:54.010 E/MethodChannel#app_badger(28454): 	at android.os.Handler.handleCallback(Handler.java:938)
02-15 11:04:54.010 E/MethodChannel#app_badger(28454): 	at android.os.Handler.dispatchMessage(Handler.java:99)
02-15 11:04:54.010 E/MethodChannel#app_badger(28454): 	at android.os.Looper.loopOnce(Looper.java:226)
02-15 11:04:54.010 E/MethodChannel#app_badger(28454): 	at android.os.Looper.loop(Looper.java:313)
02-15 11:04:54.010 E/MethodChannel#app_badger(28454): 	at android.app.ActivityThread.main(ActivityThread.java:8582)
02-15 11:04:54.010 E/MethodChannel#app_badger(28454): 	at java.lang.reflect.Method.invoke(Native Method)
02-15 11:04:54.010 E/MethodChannel#app_badger(28454): 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:563)
02-15 11:04:54.010 E/MethodChannel#app_badger(28454): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1133)